### PR TITLE
Migrate nyan to `homebrew/core`

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,0 +1,3 @@
+{
+  "nyan": "homebrew/core"
+}


### PR DESCRIPTION
This pull request updates the `tap_migrations.json` file to add a migration for the `nyan` formula, moving it to the `homebrew/core` tap.

ref. [Migrating a Formula to a Tap — Homebrew Documentation](https://docs.brew.sh/Migrating-A-Formula-To-A-Tap)