### PR TITLE
ci: Update CI to use Ruby syntax check for nyan.rb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,5 @@ jobs:
     - uses: actions/checkout@v4
     - name: brew install/test
       run: |
-        brew install -v ./*.rb
-        brew test ./*.rb
+        ruby -c nyan.rb
+        ruby -c Casks/nyan.rb


### PR DESCRIPTION
Replaces Homebrew install and test steps with Ruby syntax checks for nyan.rb and Casks/nyan.rb in the CI workflow.

installing local brew package no longer works.

```
$ brew install -v ./*.rb
Error: Homebrew requires formulae to be in a tap, rejecting:
  ./nyan.rb (/Users/toshimaru/src/github.com/toshimaru/homebrew-nyan/nyan.rb)

To create a tap, run e.g.
  brew tap-new <user|org>/<repository>
To create a formula in a tap run e.g.
  brew create <url> --tap=<user|org>/<repository>
```